### PR TITLE
cicd: update almaslennikov/reusable-release-workflows-testing images tags to network-operator-11.1-beta.1 in chart values

### DIFF
--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -1,4 +1,4 @@
 TestingComponent:
   image: reusable-release-workflows-testing
-  repository: test-repo
-  version: test-tag
+  repository: ghcr.io/almaslennikov
+  version: network-operator-11.1-beta.1


### PR DESCRIPTION
Created by the *update_network_operator_values* job.