### PR TITLE
cicd: update almaslennikov/reusable-release-workflows-testing images tags to 8cfd271 in chart values

### DIFF
--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -1,4 +1,7 @@
 TestingComponent:
   image: reusable-release-workflows-testing
-  repository: test-repo
-  version: test-tag
+  repository: ghcr.io/almaslennikov
+  version: 8cfd271
+AnotherTestingComponent:
+  repository: ghcr.io/almaslennikov
+  version: 8cfd271


### PR DESCRIPTION
Created by the *update_network_operator_values* job.