### PR TITLE
cicd: update almaslennikov/reusable-release-workflows-testing images tags to ba4716d in chart values

### DIFF
--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -1,4 +1,7 @@
 TestingComponent:
   image: reusable-release-workflows-testing
-  repository: test-repo
-  version: test-tag
+  repository: ghcr.io/almaslennikov
+  version: ba4716d
+AnotherTestingComponent:
+  repository: ghcr.io/almaslennikov
+  version: ba4716d


### PR DESCRIPTION
Created by the *update_network_operator_values* job.